### PR TITLE
Fix autoscaling

### DIFF
--- a/bizflycloud/resource_bizflycloud_autoscaling_group.go
+++ b/bizflycloud/resource_bizflycloud_autoscaling_group.go
@@ -167,7 +167,7 @@ func newStateRefreshfunc(d *schema.ResourceData, attribute string, meta interfac
 			return nil, "", err
 		}
 		// if the task is not ready, we need to wait for a moment
-		if !resp.Ready {
+		if !resp.Ready && len(resp.Result.Action) > 0 {
 			log.Println("[DEBUG] auto scaling is not ready")
 			return nil, "", nil
 		}

--- a/bizflycloud/resource_bizflycloud_autoscaling_launch_configuration.go
+++ b/bizflycloud/resource_bizflycloud_autoscaling_launch_configuration.go
@@ -152,9 +152,15 @@ func readBlockDeviceMappingFromConfig(bdm map[string]interface{}) *gobizfly.Auto
 }
 
 func readNetworksFromConfig(net map[string]interface{}) *gobizfly.AutoScalingNetworks {
+	securityGroupSet := net["security_groups"].(*schema.Set)
+	securityGroups := make([]*string, securityGroupSet.Len())
+	for _, i := range securityGroupSet.List() {
+		securityGroups = append(securityGroups, i.(*string))
+	}
+
 	network := &gobizfly.AutoScalingNetworks{
 		ID:             net["network_id"].(string),
-		SecurityGroups: net["security_groups"].([]*string),
+		SecurityGroups: securityGroups,
 	}
 
 	return network

--- a/bizflycloud/schema_bizflycloud_autoscaling.go
+++ b/bizflycloud/schema_bizflycloud_autoscaling.go
@@ -480,11 +480,11 @@ func resourceLaunchConfigurationSchema() map[string]*schema.Schema {
 				Schema: map[string]*schema.Schema{
 					"network_id": {
 						Type:     schema.TypeString,
-						Computed: true,
+						Required: true,
 					},
 					"security_groups": {
 						Type:     schema.TypeSet,
-						Computed: true,
+						Optional: true,
 						Elem:     &schema.Schema{Type: schema.TypeString},
 					},
 				},

--- a/bizflycloud/schema_bizflycloud_autoscaling.go
+++ b/bizflycloud/schema_bizflycloud_autoscaling.go
@@ -431,6 +431,7 @@ func resourceLaunchConfigurationSchema() map[string]*schema.Schema {
 					"volume_size": {
 						Type:     schema.TypeInt,
 						Required: true,
+						ForceNew: true,
 						ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 							switch v := val.(int); true {
 							case v < 20 || v%10 > 0:
@@ -481,10 +482,12 @@ func resourceLaunchConfigurationSchema() map[string]*schema.Schema {
 					"network_id": {
 						Type:     schema.TypeString,
 						Required: true,
+						ForceNew: true,
 					},
 					"security_groups": {
 						Type:     schema.TypeSet,
 						Optional: true,
+						ForceNew: true,
 						Elem:     &schema.Schema{Type: schema.TypeString},
 					},
 				},
@@ -515,10 +518,12 @@ func resourceLaunchConfigurationSchema() map[string]*schema.Schema {
 					"uuid": {
 						Type:     schema.TypeString,
 						Required: true,
+						ForceNew: true,
 					},
 					"os_name": {
 						Type:     schema.TypeString,
 						Computed: true,
+						ForceNew: true,
 					},
 				},
 			},
@@ -534,14 +539,17 @@ func resourceLaunchConfigurationSchema() map[string]*schema.Schema {
 						Type:     schema.TypeBool,
 						Optional: true,
 						Default:  true,
+						ForceNew: true,
 					},
 					"volume_size": {
 						Type:     schema.TypeInt,
 						Required: true,
+						ForceNew: true,
 					},
 					"volume_type": {
 						Type:     schema.TypeString,
 						Required: true,
+						ForceNew: true,
 					},
 				},
 			},


### PR DESCRIPTION
Applying below schema will raise error. This PR attempt to fix that 

```hcl
resource "bizflycloud_autoscaling_launch_configuration" "office1_agent__basic_hdd_2c_2g_bw" {
  name = "office1_agent__basic_hdd_2c_2g_bw"
  ssh_key = bizflycloud_ssh_key.default.name
  availability_zone = "HN1"
  flavor = "2c_2g_basic"
  instance_type = "basic"
  network_plan = "free_bandwidth"
  os {
    uuid = data.bizflycloud_image.ubuntu18.id
    create_from = "image"
  }
  rootdisk {
    volume_type = "BASIC_SSD1"
    volume_size = 20
    delete_on_termination = true
  }
  networks {
    network_id = "wan"
  }
  networks {
    network_id = "b7143f67-ab30-4fe3-b381-6a182a1d030c"
  }
  user_data = <<USERDATA
#!/bin/bash
USERDATA
}
```

Errors are:

- `network_id` was Computed so couldn't set value
- Couldn't cast `security_groups` to `[]string`
- Fix stucking when update autoscaling
- `ForceNew: true` for modification inside nested schema in autoscaling configuration