### PR TITLE
Fix#bug server and vpc network and network interface resource

### DIFF
--- a/bizflycloud/resource_bizflycloud_server.go
+++ b/bizflycloud/resource_bizflycloud_server.go
@@ -191,6 +191,7 @@ func resourceBizflyCloudServerRead(d *schema.ResourceData, meta interface{}) err
 		serverNetworkInterface["id"] = networkInterface.ID
 		serverNetworkInterface["firewall_ids"] = networkInterface.SecurityGroups
 		serverNetworkInterface["enabled"] = networkInterface.Status == "ACTIVE"
+		serverNetworkInterface["ip_address"] = networkInterface.IPAddress
 		if networkInterface.Type == "WAN" && networkInterface.BillingType == "free" {
 			if networkInterface.IPVersion == 6 {
 				_ = d.Set("default_public_ipv6", []map[string]interface{}{serverNetworkInterface})

--- a/bizflycloud/resource_bizflycloud_server.go
+++ b/bizflycloud/resource_bizflycloud_server.go
@@ -181,8 +181,8 @@ func resourceBizflyCloudServerRead(d *schema.ResourceData, meta interface{}) err
 	}
 	vpcNetworkIDs := make([]string, 0)
 	networkInterfaceIds := make([]string, 0)
-	d.Set("default_public_ipv6", make([]map[string]interface{}, 0))
-	d.Set("default_public_ipv4", make([]map[string]interface{}, 0))
+	_ = d.Set("default_public_ipv6", make([]map[string]interface{}, 0))
+	_ = d.Set("default_public_ipv4", make([]map[string]interface{}, 0))
 	for _, networkInterface := range networkInterfaces {
 		if networkInterface.DeviceID != d.Id() {
 			continue

--- a/bizflycloud/resource_bizflycloud_server.go
+++ b/bizflycloud/resource_bizflycloud_server.go
@@ -227,6 +227,13 @@ func resourceBizflyCloudServerRead(d *schema.ResourceData, meta interface{}) err
 func resourceBizflyCloudServerUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).gobizflyClient()
 	id := d.Id()
+	if d.HasChange("name") {
+		// Rename server
+		newName := d.Get("name").(string)
+		if err := client.Server.Rename(context.Background(), id, newName); err != nil {
+			return fmt.Errorf("Error when rename server [%s]: %v", id, err)
+		}
+	}
 	if d.HasChange("flavor_name") {
 		// Resize server to new flavor
 		task, err := client.Server.Resize(context.Background(), id, d.Get("flavor_name").(string))

--- a/bizflycloud/resource_bizflycloud_server.go
+++ b/bizflycloud/resource_bizflycloud_server.go
@@ -181,6 +181,8 @@ func resourceBizflyCloudServerRead(d *schema.ResourceData, meta interface{}) err
 	}
 	vpcNetworkIDs := make([]string, 0)
 	networkInterfaceIds := make([]string, 0)
+	d.Set("default_public_ipv6", make([]map[string]interface{}, 0))
+	d.Set("default_public_ipv4", make([]map[string]interface{}, 0))
 	for _, networkInterface := range networkInterfaces {
 		if networkInterface.DeviceID != d.Id() {
 			continue

--- a/bizflycloud/schema_bizflycloud_server.go
+++ b/bizflycloud/schema_bizflycloud_server.go
@@ -137,5 +137,9 @@ func resourceServerFreeWANNetworkInterfaceSchema() map[string]*schema.Schema {
 			Default:  true,
 			Optional: true,
 		},
+		"ip_address": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 	}
 }

--- a/bizflycloud/schema_bizflycloud_vpc_network.go
+++ b/bizflycloud/schema_bizflycloud_vpc_network.go
@@ -64,6 +64,7 @@ func resourceVPCNetworkSchema() map[string]*schema.Schema {
 		"cidr": {
 			Type:     schema.TypeString,
 			Optional: true,
+			Computed: true,
 		},
 		"is_default": {
 			Type:     schema.TypeBool,

--- a/website/docs/r/firewall.html.markdown
+++ b/website/docs/r/firewall.html.markdown
@@ -46,6 +46,7 @@ The following arguments are supported:
 * `name` - (Required) Name of the firewall
 * `ingress` - (Optional) Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below
 * `egress` - (Optional) Can be specified multiple times for each egress rule. Each egress block supports fields documented below.
+* `network_interfaces` - (Optional) Can be specified network interfaces use the firewall.
 
 The `ingress` and `egress` block supports:
 
@@ -67,3 +68,4 @@ The following attributes are exported:
   * `port_range` - Port range. Example: `80` or `8000-9000`
 * `rules_count` - Number of rules of the firewall
 * `network_interface_count` - Number of network interface of the firewall
+* `network_interfaces` - (Optional) Can be specified network interfaces use the firewall.


### PR DESCRIPTION
Change logs:

- Export IPv4 and IPv6 default for server resource. 
- Fix bug rename server.
- Fix bug updated in-place for vpc network and default public wan ip.
- Fix bug missing network interfaces for firewall docs.

**Issue**: https://sapd.notion.site/Cloud-Server-da16e497b93d4203a3b12e72cbfce3f3