### PR TITLE
fix: raise delete network interface but not found

### DIFF
--- a/bizflycloud/resource_bizflycloud_network_interface.go
+++ b/bizflycloud/resource_bizflycloud_network_interface.go
@@ -96,7 +96,7 @@ func resourceBizflyCloudNetworkInterfaceUpdate(d *schema.ResourceData, meta inte
 func resourceBizflyCloudNetworkInterfaceDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*CombinedConfig).gobizflyClient()
 	err := client.CloudServer.NetworkInterfaces().Delete(context.Background(), d.Id())
-	if err != nil && strings.Contains(err.Error(), "Resource not found") {
+	if err != nil && !strings.Contains(err.Error(), "Resource not found") {
 		return fmt.Errorf("error when delete network interface: %v", err)
 	}
 	return nil


### PR DESCRIPTION
Change logs:
 - Ignore raise error when delete network interface but not found.